### PR TITLE
Aj/improved styles

### DIFF
--- a/_includes/news-box
+++ b/_includes/news-box
@@ -1,17 +1,17 @@
-<!--news line 1-->
+		<!--news line 1-->
         <p>
+        <a href="https://github.com/InternationalTradeAdministration/developerportal/wiki/Submit-Your-App-that-Uses-ITA's-APIs">
+        <p class="news">Have you used ITA's APIs to create a cool app or Web page?  Let us know.</p>
+        </a>
+        <h7>May 4, 2015</h7>
+        </p>
+        
+        <!--news line 2-->
+        <p class="list">
         <a href="https://github.com/InternationalTradeAdministration/developerportal/wiki/Version-2-of-ITA%E2%80%99s-Data-Services-Platform-Released">
         <p class="news">Version 2 of ITA's Data Services Platform Released.</p>
         </a>
         <h7>March 31, 2015</h7>
-        </p>
-            
-        <!--news line 2-->
-        <p class="list">
-        <a href="https://github.com/InternationalTradeAdministration/developerportal/wiki/We%27ll-Be-At-Collaborate-2015!-on-January-23">
-        <p class="news">We'll Be At Collaborate 2015! in Washington DC on January 23.</p>
-        </a>
-        <h7>January 19, 2015</h7>
         </p>
         
         <!--news line 3-->

--- a/_posts/2014-11-15-app-gallery.md
+++ b/_posts/2014-11-15-app-gallery.md
@@ -23,9 +23,7 @@ ITA has developed [simple search apps for each API](demo-search-apps.html) desig
 
 [![businessusa](images/businessusa.png)](http://business.usa.gov/export)
 
-**BusinessUSA** helps small businesses find the government resources they need. Their [Exporting](http://business.usa.gov/export) section automatically populates its pages using ITA's [Trade Events](http://business.usa.gov/events-search/) and [Offices & Centers APIs](http://business.usa.gov/export). 
-
-Just click Change Location and enter a new zip code to see the results.
+**BusinessUSA** helps small businesses find the government resources they need. Their [Exporting](http://business.usa.gov/export) section automatically populates its pages using ITA's [Trade Events](http://business.usa.gov/events-search/) and [Offices & Centers APIs](http://business.usa.gov/export). Just click Change Location and enter a new zip code to see the results.
 
 ------
 

--- a/_posts/v1/2013-08-21-market-research-library.markdown
+++ b/_posts/v1/2013-08-21-market-research-library.markdown
@@ -1,6 +1,6 @@
 ---
 published: true
-permalink: "/v1/market-research-library.html"
+permalink: "/v1-market-research-library.html"
 title: Market Research Library API
 layout: body
 ---

--- a/_posts/v1/2013-08-21-trade-events.markdown
+++ b/_posts/v1/2013-08-21-trade-events.markdown
@@ -1,5 +1,5 @@
 ---
-permalink: "/v1/trade-events.html"
+permalink: "/v1-trade-events.html"
 layout: body
 title: Trade Events API
 published: true

--- a/_posts/v1/2013-09-05-trade-news-articles.markdown
+++ b/_posts/v1/2013-09-05-trade-news-articles.markdown
@@ -1,11 +1,11 @@
 ---
-permalink: "/v1/trade-news-articles.html"
+permalink: "/v1-ita-trade-articles.html"
 layout: body
 title: Trade News & Articles API
 published: true
 ---
 
-#####This is an old version of the API and will be deprecated soon. Please upgrade to the [new version of the API]({{ site.baseurl }}/trade-news-articles.html).
+#####This is an old version of the API and will be deprecated soon. Please upgrade to the [new version of the API]({{ site.baseurl }}/ita-trade-articles.html).
 
 #Trade News & Articles API
 

--- a/_posts/v1/2014-07-25-trade-leads.md
+++ b/_posts/v1/2014-07-25-trade-leads.md
@@ -1,5 +1,5 @@
 ---
-permalink: "/v1/trade-leads.html"
+permalink: "/v1-trade-leads.html"
 layout: body
 title: Trade Leads API
 published: true

--- a/_posts/v1/2014-12-17-csl.md
+++ b/_posts/v1/2014-12-17-csl.md
@@ -1,5 +1,5 @@
 ---
-permalink: "/v1/consolidated-screening-list.html"
+permalink: "/v1-consolidated-screening-list.html"
 layout: body
 title: Consolidated Screening API
 published: true

--- a/_posts/v2/2014-11-17-ita-articles.markdown
+++ b/_posts/v2/2014-11-17-ita-articles.markdown
@@ -202,4 +202,4 @@ The size parameter allows you to configure the maximum amount of hits to be retu
 | url_html_source             | The URL for the HTML of the article's source.     |
 | url_xml_source            | The URL for the XML of the article's source.    |
 
-This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1/trade-news-articles.html) page for the Version 1 documentation.
+This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1-ita-trade-articles.html) page for the Version 1 documentation.

--- a/_posts/v2/2015-02-14-trade-events.md
+++ b/_posts/v2/2015-02-14-trade-events.md
@@ -153,6 +153,6 @@ Each event source returns a unique set of fields.  Not every source provides all
 | cost_currency      | The currency of the cost value          | USTDA										|
 
 
-This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1/trade-events.html) page for the Version 1 documentation.
+This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1-trade-events.html) page for the Version 1 documentation.
 
 

--- a/_posts/v2/2015-02-24-csl.md
+++ b/_posts/v2/2015-02-24-csl.md
@@ -380,4 +380,4 @@ ITA’s data services platform imports each of the eleven screening lists once a
 There can be a time lag of up to one day between the time a Source has updated a screening list and when that update appears in the Consolidated Screening List API. Furthermore, the Consolidated Screening List API is not the system of record for these screening lists.  Developers should strongly encourage users to refer to the website of the source agency for further instructions when finding a potential match.  Links to these websites are found above as well as in the “Source List URL” and “Source Information URL” fields that accompany each party returned in the API. 
 
 ---
-This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1/consolidated-screening-list.html) page for the Version 1 documentation.
+This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1-consolidated-screening-list.html) page for the Version 1 documentation.

--- a/_posts/v2/2015-02-24-market-research-library.md
+++ b/_posts/v2/2015-02-24-market-research-library.md
@@ -78,4 +78,4 @@ The **size** parameter allows you to configure the number of results to be retur
 | url             | URL for the report                                              |
 
 
-This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1/market-research-library.html) page for the Version 1 documentation.
+This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1-market-research-library.html) page for the Version 1 documentation.

--- a/_posts/v2/2015-02-24-trade-leads.md
+++ b/_posts/v2/2015-02-24-trade-leads.md
@@ -234,5 +234,5 @@ UK leads are subject to their open government license located at:
 | specific_location               | Location of the opportunity | 
 | source                          | UK |
 
-This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1/trade-leads.html) page for the Version 1 documentation.
+This endpoint and its documentation has been updated to Version 2. Please visit the [API v1 Documentation]({{ site.baseurl }}/v1-trade-leads.html) page for the Version 1 documentation.
 

--- a/guidance.html
+++ b/guidance.html
@@ -24,7 +24,8 @@ Title: Guidance
   <body>
   
   {% include topbar.html %}
-    <div class="wrapper" style="margin-top:50px;">
+  <div class="container">
+    <div class="wrapper" >
       {% include header.html %}
       
       
@@ -167,6 +168,7 @@ Title: Guidance
                     sites should not be construed as an endorsement of the views or privacy policies contained therein.</p>
         </section>
       
+    </div>
     </div>
     <script src="javascripts/scale.fix.js"></script>
     <script src="http://code.jquery.com/jquery-1.8.3.min.js"></script>

--- a/stylesheets/bootstrap.min.css
+++ b/stylesheets/bootstrap.min.css
@@ -1587,7 +1587,7 @@ pre code {
 
 @media (min-width:1200px) {
 .container {
-    width:1300px
+    width:1170px
 }
 }
 

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -103,14 +103,14 @@ blockquote {
 
 
 #info {
-max-width:650px;	
+max-width:550px;	
 display: inline-block;
 float:left;
 padding-right: 10px;
 }
 
 #side {
-width:275px;	
+width:250px;	
 display: inline-block;
 float:left;
 }
@@ -346,7 +346,7 @@ font-size:12.5px;
 }
 
 #sect2 ul{
-display:inline-block;float:left;max-width:160px;margin:0px;padding:0px;margin-right:30px;
+display:inline-block;float:left;max-width:160px;margin:0px;padding:0px;margin-right:15px;
 }
 
 #sect2 .last{
@@ -763,6 +763,11 @@ td:before {
 	padding-right: 10px; 
 	white-space: nowrap;
 }
+
+.api-explorer .btn, .api-demo .btn {
+font-size:6px;
+}
+
 }
 
 @media print {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -77,7 +77,7 @@ a small {
 }
 
 .wrapper {
-  width:1250px;
+  width:1120px;
   margin:0 auto;
   margin-top:50px;
 }
@@ -295,7 +295,7 @@ header ul a strong {
 }
 
 section {
-  width:1000px;
+  width:880px;
   float:right;
   padding:30px 15px ;
   background:#fff;


### PR DESCRIPTION
@calumhalcrow I fixed the latest issues that Stuart pointed out. 
1. Fixed the missing screen size, by narrowing everything out to Bootstrap's 1170px container width. 
2. The V1 documentation somehow pointed to its own links through the navigation. It was missing the baseurl path from the config file call, but that did not fix it for me either. So I just removed the v1 folder from the path and added "v1-“ in the permalink.
3. Added the container div on Guidance page
4. Updated the index.html (homepage) widths to match. Also, moved some text over from production into staging (Stuart pushed some text changes directly to production last week).

The last item about the JSON link wrapping to next line is a little tricky because its a button. I don’t think this item is necessary to fix right away, but I can work on it more tomorrow. He is demoing this staging version to Kim at ITA tomorrow. 

Please merge if you think these changes are ready. Thanks. 
